### PR TITLE
Fix PixelCPEFast._cpuData on move by adding a __moveinit__; simplify …

### DIFF
--- a/src/mojo-serial/MojoSerial/CUDADataFormats/SiPixelClustersSoA.mojo
+++ b/src/mojo-serial/MojoSerial/CUDADataFormats/SiPixelClustersSoA.mojo
@@ -58,7 +58,14 @@ struct SiPixelClustersSoA(Defaultable, Movable, Typeable):
         self.clusInModule_d = OwnedPointer(List[UInt32]())
         self.moduleId_d = OwnedPointer(List[UInt32]())
         self.clusModuleStart_d = OwnedPointer(List[UInt32]())
-        self.view_d = OwnedPointer(DeviceConstView())
+        self.view_d = OwnedPointer(
+            DeviceConstView(
+                self.moduleStart_d[].unsafe_ptr(),
+                self.clusInModule_d[].unsafe_ptr(),
+                self.moduleId_d[].unsafe_ptr(),
+                self.clusModuleStart_d[].unsafe_ptr(),
+            )
+        )
         self.nClusters_h = 0
 
     fn __init__(out self, maxClusters: SizeType):
@@ -86,12 +93,19 @@ struct SiPixelClustersSoA(Defaultable, Movable, Typeable):
         self.nClusters_h = 0
 
     fn __moveinit__(out self, var other: Self):
-        self.view_d = other.view_d^
         self.moduleStart_d = other.moduleStart_d^
         self.clusInModule_d = other.clusInModule_d^
         self.moduleId_d = other.moduleId_d^
         self.clusModuleStart_d = other.clusModuleStart_d^
         self.nClusters_h = other.nClusters_h
+        self.view_d = OwnedPointer(
+            DeviceConstView(
+                self.moduleStart_d[].unsafe_ptr(),
+                self.clusInModule_d[].unsafe_ptr(),
+                self.moduleId_d[].unsafe_ptr(),
+                self.clusModuleStart_d[].unsafe_ptr(),
+            )
+        )
 
     fn view(self) -> UnsafePointer[DeviceConstView, mut=False]:
         return self.view_d.unsafe_ptr()

--- a/src/mojo-serial/MojoSerial/CUDADataFormats/SiPixelDigisSoA.mojo
+++ b/src/mojo-serial/MojoSerial/CUDADataFormats/SiPixelDigisSoA.mojo
@@ -109,6 +109,29 @@ struct SiPixelDigisSoA(Defaultable, Movable, Typeable):
         self.nModules_h = 0
         self.nDigis_h = 0
 
+    fn __moveinit__(out self, var other: Self):
+        self.xx_d = other.xx_d^
+        self.yy_d = other.yy_d^
+        self.adc_d = other.adc_d^
+        self.moduleInd_d = other.moduleInd_d^
+        self.clus_d = other.clus_d^
+
+        self.pdigi_d = other.pdigi_d^
+        self.rawIdArr_d = other.rawIdArr_d^
+
+        self.nModules_h = other.nModules_h
+        self.nDigis_h = other.nDigis_h
+
+        self.view_d = OwnedPointer(
+            DeviceConstView(
+                self.xx_d[].unsafe_ptr(),
+                self.yy_d[].unsafe_ptr(),
+                self.adc_d[].unsafe_ptr(),
+                self.moduleInd_d[].unsafe_ptr(),
+                self.clus_d[].unsafe_ptr(),
+            )
+        )
+
     @always_inline
     fn view(self) -> UnsafePointer[DeviceConstView, mut=False]:
         return self.view_d.unsafe_ptr()

--- a/src/mojo-serial/MojoSerial/CondFormats/PixelCPEFast.mojo
+++ b/src/mojo-serial/MojoSerial/CondFormats/PixelCPEFast.mojo
@@ -60,6 +60,19 @@ struct PixelCPEFast(Defaultable, Movable, Typeable):
             UnsafePointer(to=self.m_averageGeometry),
         )
 
+    fn __moveinit__(out self, var other: Self):
+        self.m_detParamsGPU = other.m_detParamsGPU^
+        self.m_commonParamsGPU = other.m_commonParamsGPU
+        self.m_layerGeometry = other.m_layerGeometry^
+        self.m_averageGeometry = other.m_averageGeometry^
+
+        self._cpuData = ParamsOnGPU(
+            UnsafePointer(to=self.m_commonParamsGPU),
+            self.m_detParamsGPU.unsafe_ptr(),
+            UnsafePointer(to=self.m_layerGeometry),
+            UnsafePointer(to=self.m_averageGeometry),
+        )
+
     @always_inline
     fn getCPUProduct(self) -> ref [self._cpuData] ParamsOnGPU:
         return self._cpuData

--- a/src/mojo-serial/MojoSerial/Framework/ESProducer.mojo
+++ b/src/mojo-serial/MojoSerial/Framework/ESProducer.mojo
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 from MojoSerial.Framework.EventSetup import EventSetup
+from MojoSerial.MojoBridge.DTypes import Typeable
 
-
-trait ESProducer(Defaultable):
+trait ESProducer(Copyable, Defaultable, Movable, Typeable):
     fn __init__(out self, var path: Path):
         ...
 

--- a/src/mojo-serial/MojoSerial/bin/EventProcessor.mojo
+++ b/src/mojo-serial/MojoSerial/bin/EventProcessor.mojo
@@ -62,7 +62,7 @@ struct EventProcessor(Defaultable, Typeable):
                 esp.produce(self._eventSetup)
 
             self._schedule = StreamSchedule(
-                UnsafePointer(to=self._registry),
+                self._registry,
                 UnsafePointer(to=self._source),
                 UnsafePointer(to=self._eventSetup),
                 edreg,
@@ -95,7 +95,7 @@ struct EventProcessor(Defaultable, Typeable):
     @always_inline
     fn process(mut self):
         self._source.startProcessing()
-        self._schedule.run()
+        self._schedule.run(self._registry)
 
     @always_inline
     fn endJob(mut self) raises:

--- a/src/mojo-serial/MojoSerial/bin/StreamSchedule.mojo
+++ b/src/mojo-serial/MojoSerial/bin/StreamSchedule.mojo
@@ -9,7 +9,6 @@ from MojoSerial.bin.Source import Source
 
 
 struct StreamSchedule(Defaultable, Movable, Typeable):
-    var _registry: UnsafePointer[ProductRegistry]
     var _source: UnsafePointer[Source]
     var _eventSetup: UnsafePointer[EventSetup]
     var _path: List[EDProducerConcrete]
@@ -17,7 +16,6 @@ struct StreamSchedule(Defaultable, Movable, Typeable):
 
     @always_inline
     fn __init__(out self):
-        self._registry = UnsafePointer[ProductRegistry]()
         self._source = UnsafePointer[Source]()
         self._eventSetup = UnsafePointer[EventSetup]()
         self._path = []
@@ -25,14 +23,13 @@ struct StreamSchedule(Defaultable, Movable, Typeable):
 
     fn __init__(
         out self,
-        reg: UnsafePointer[ProductRegistry],
+        mut reg: ProductRegistry,
         source: UnsafePointer[Source],
         eventSetup: UnsafePointer[EventSetup],
         mut edreg: MojoSerial.Framework.PluginFactory.Registry,
         streamId: Int32 = 0,
     ):
         try:
-            self._registry = reg
             self._source = source
             self._eventSetup = eventSetup
             self._streamId = streamId
@@ -46,15 +43,15 @@ struct StreamSchedule(Defaultable, Movable, Typeable):
 
             var i: UInt = 0
             for name in PluginFactory.getAll(edreg):
-                self._registry[].beginModuleConstruction(i + 1)
+                reg.beginModuleConstruction(i + 1)
                 producers.append(
-                    PluginFactory.create(name, self._registry[], edreg)
+                    PluginFactory.create(name, reg, edreg)
                 )
-                var dep_indices = self._registry[].consumedModules()
+                var dep_indices = reg.consumedModules()
                 # remove dependency on FEDRawDataCollection from resolver logic
                 # it is the parent of all producers (guaranteed by Source)
                 if 0 in dep_indices:
-                    dep_indices.remove(0)
+                    _ = dep_indices.pop(0)
                 in_degree[i] = dep_indices.__len__()
 
                 for dep_index in dep_indices:
@@ -91,21 +88,20 @@ struct StreamSchedule(Defaultable, Movable, Typeable):
 
     @always_inline
     fn __moveinit__(out self, var other: Self):
-        self._registry = other._registry
         self._source = other._source
         self._eventSetup = other._eventSetup
         self._path = other._path^
         self._streamId = other._streamId
 
-    fn run(mut self):
+    fn run(mut self, ref reg: ProductRegistry):
         var event: Event
-        var ptr = self._source[].produce(self._streamId, self._registry[])
+        var ptr = self._source[].produce(self._streamId, reg)
         while ptr != UnsafePointer[Event]():
             event = ptr.take_pointee()
             ptr.free()
             for i in range(self._path.__len__()):
                 self._path[i].produce(event, self._eventSetup[])
-            ptr = self._source[].produce(self._streamId, self._registry[])
+            ptr = self._source[].produce(self._streamId, reg)
 
     fn endJob(mut self) raises:
         for i in range(self._path.__len__()):

--- a/src/mojo-serial/MojoSerial/plugin_BeamSpotProducer/BeamSpotESProducer.mojo
+++ b/src/mojo-serial/MojoSerial/plugin_BeamSpotProducer/BeamSpotESProducer.mojo
@@ -9,9 +9,7 @@ from MojoSerial.MojoBridge.DTypes import Char, Typeable, UChar
 from MojoSerial.MojoBridge.File import read_obj
 
 @fieldwise_init
-struct BeamSpotESProducer(
-    Defaultable, ESProducer, Movable, Typeable
-):
+struct BeamSpotESProducer(ESProducer):
     var _data: Path
 
     @always_inline

--- a/src/mojo-serial/MojoSerial/plugin_PixelTriplets/GPUCACell.mojo
+++ b/src/mojo-serial/MojoSerial/plugin_PixelTriplets/GPUCACell.mojo
@@ -150,10 +150,23 @@ struct GPUCACell(Copyable, Defaultable, Movable):
         self.theInnerZ = hh.zGlobal(innerIdx)
         self.theInnerR = hh.rGlobal(innerIdx)
 
-        self.theOuterNeighbors = UnsafePointer(to=cellNeighbors[0])
-        self.theTracks = UnsafePointer(to=cellTracks[0])
+        self.theOuterNeighbors = UnsafePointer(to=self.cellNeighbors[0])
+        self.theTracks = UnsafePointer(to=self.cellTracks[0])
         assert self.outerNeighbors().empty()
         assert self.tracks().empty()
+
+    fn __moveinit__(out self, var other: Self):
+        self.theDoubletId = other.theDoubletId
+        self.theLayerPairId = other.theLayerPairId
+        self.theUsed = other.theUsed
+
+        self.theInnerZ = other.theInnerZ
+        self.theInnerR = other.theInnerR
+        self.theInnerHitId = other.theInnerHitId
+        self.theOuterHitId = other.theOuterHitId
+
+        self.theOuterNeighbors = UnsafePointer(to=self.cellNeighbors[0])
+        self.theTracks = UnsafePointer(to=self.cellTracks[0])
 
     @always_inline
     fn addOuterNeighbor(

--- a/src/mojo-serial/MojoSerial/plugin_SiPixelClusterizer/SiPixelFedCablingMapGPUWrapperESProducer.mojo
+++ b/src/mojo-serial/MojoSerial/plugin_SiPixelClusterizer/SiPixelFedCablingMapGPUWrapperESProducer.mojo
@@ -18,9 +18,7 @@ from MojoSerial.MojoBridge.File import (
 
 
 @fieldwise_init
-struct SiPixelFedCablingMapGPUWrapperESProducer(
-    Defaultable, ESProducer, Movable, Typeable
-):
+struct SiPixelFedCablingMapGPUWrapperESProducer(ESProducer):
     var _data: Path
 
     @always_inline

--- a/src/mojo-serial/MojoSerial/plugin_SiPixelClusterizer/SiPixelGainCalibrationForHLTGPUESProducer.mojo
+++ b/src/mojo-serial/MojoSerial/plugin_SiPixelClusterizer/SiPixelGainCalibrationForHLTGPUESProducer.mojo
@@ -11,9 +11,7 @@ from MojoSerial.MojoBridge.File import read_simd, read_obj
 
 
 @fieldwise_init
-struct SiPixelGainCalibrationForHLTGPUESProducer(
-    Defaultable, ESProducer, Movable, Typeable
-):
+struct SiPixelGainCalibrationForHLTGPUESProducer(ESProducer):
     var _data: Path
 
     @always_inline

--- a/src/mojo-serial/MojoSerial/plugin_SiPixelRecHits/PixelCPEFastESProducer.mojo
+++ b/src/mojo-serial/MojoSerial/plugin_SiPixelRecHits/PixelCPEFastESProducer.mojo
@@ -6,7 +6,7 @@ from MojoSerial.Framework.EventSetup import EventSetup
 from MojoSerial.MojoBridge.DTypes import Typeable
 
 
-struct PixelCPEFastESProducer(Defaultable, ESProducer, Movable, Typeable):
+struct PixelCPEFastESProducer(ESProducer):
     var _data: Path
 
     @always_inline


### PR DESCRIPTION
…lifetime handling of ProductRegistry.